### PR TITLE
Bump eslint version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/Globegitter/sails-hook-eslint",
   "dependencies": {
     "chalk": "^1.0.0",
-    "eslint": "^0.18.0",
+    "eslint": "^1.2.0",
     "glob": "^5.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
I can’t used parser babel-eslint because eslint version too old.
